### PR TITLE
Support creation of change requests without producer

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Every step must provide these two arguments in order to connect to the ServiceNo
 
 ### `serviceNow_createChange`
 
-#### Required Parameters
+#### Optional Parameters
 
 `serviceNowConfiguration`
 * `producerId` - Producer ID of the standard change to create

--- a/src/main/java/org/jenkinsci/plugins/servicenow/model/ServiceNowConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/servicenow/model/ServiceNowConfiguration.java
@@ -3,6 +3,7 @@ package org.jenkinsci.plugins.servicenow.model;
 import hudson.Extension;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
+import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
@@ -70,7 +71,11 @@ public class ServiceNowConfiguration extends AbstractDescribableImpl<ServiceNowC
     }
 
     public String getProducerRequestUrl() {
-        return getBaseUrl()+"/"+PRODUCER_URI+"/"+getProducerId()+"/submit_producer";
+        if (StringUtils.isBlank(getProducerId())) {
+            return getBaseUrl()+"/"+TABLE_API+"/change_request";
+        } else {
+            return getBaseUrl()+"/"+PRODUCER_URI+"/"+getProducerId()+"/submit_producer";
+        }
     }
 
     public String getBaseUrl() {


### PR DESCRIPTION
This adds support for creating a change request directly via the change_request table API without a producer.